### PR TITLE
Fix #1

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,7 +26,7 @@ app.get("/", (req, res) => {
     })
 })
 
-app.post("/", async (req, res) => {
+app.post("/whois", async (req, res) => {
     if(req.body.user) res.redirect(`/${req.body.user}`)
     else res.redirect("/404")
 })

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -29,7 +29,7 @@
                     </a>
                 </h2>
             </div>
-            <form method="POST">
+            <form method="POST" action="/whois">
                 <label for="userid" class="usr_title">User ID</label>
                 <input type="text" id="userid" name="user"
                        autocomplete="off" placeholder="Enter the user ID. Example : 308655472452304896"


### PR DESCRIPTION
🚀 Correctif #1

🔎 Description rapide du problème et du correctif :
Lorsque vous entriez un identifiant invalide pour la première fois, vous étiez directement redirigé vers la page de cet identifiant (ex : /123). Ensuite, lorsque vous entriez à nouveau un identifiant (valide ou non) pour le rechercher, le formulaire (balise form) envoyait la requête à l'URL POST:/123 (voir l'attribut "[action](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#action)").

Avec ma correction, toutes les requêtes POST pour rechercher un identifiant sont désormais envoyées vers l'URL POST:/whois. Pour cette modification, j'ai simplement ajouter cette URL à l'attribut "[action](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#action)" de la balise form !